### PR TITLE
fix: improve error handling for missing output.html.print setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 name = "mdbook-pdf"
 readme = "README.md"
 repository = "https://github.com/HollowMan6/mdbook-pdf"
-version = "0.1.7"
+version = "0.1.8"
 include = [
     "**/*.rs",
     "Cargo.toml",

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .to_owned();
 
+    if !PathBuf::from(&print_html_path).exists() {
+        println!(
+            "PDF generation failed. The print.html file does not exist at {}.",
+            print_html_path
+        );
+        println!("Verify output.html is active and output.html.print.enabled is set to true in your book.toml.");
+        return Err(Box::try_from(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("File not found: {}", print_html_path),
+        ))
+        .unwrap());
+    }
+
     // Modify the print.html for custom JS scripts as well as links outside the book.
     let file = fs::OpenOptions::new()
         .read(true)


### PR DESCRIPTION
I pulled my hair out for a few hours trying to figure out why the "pdf" backend kept failing after I had all dependencies installed. The docs indicate that `output.html.print` is enabled by default. For one reason or another, this was not active for
me the resulting stack trace is not very informative. This adds an error check to the code to improve the output when this circumstance is encountered.