### PR TITLE
Updated description to take account for docker architecture compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ You can also use this [docker image](https://hub.docker.com/r/hollowman6/mdbook-
 docker run --rm -v /path/to/book:/book hollowman6/mdbook-pdf
 ```
 
+If you encounter architecture compatibility issues, like `docker: no matching manifest for linux/arm64/v8 in the manifest list entries.`, you may need to specify the platform architecture using --platform linux/amd64. The command would then look like this:
+```bash
+docker run --rm --platform linux/amd64 -v /path/to/book:/book hollowman6/mdbook-pdf
+```
+
 If your book have other Rust dependencies, you can install them on your local machine (if using Linux), or if you are not using Linux, download the Linux executables of corresponding architecture to a dir, replace `~/.cargo/bin` with your path.
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -72,6 +72,12 @@ title = "An Example"
 docker run --rm -v /path/to/book:/book hollowman6/mdbook-pdf
 ```
 
+如果您遇到架构兼容性问题，例如`docker: no matching manifest for linux/arm64/v8 in the manifest list entries.`，您可能需要使用 `--platform linux/amd64` 指定平台架构：
+
+````bash
+docker run --rm --platform linux/amd64 -v /path/to/book:/book Hollowman6/mdbook-pdf
+````
+
 如果你的书有其他 Rust 依赖项，你可以在你的本地机器上安装它们（如果使用 Linux），或者如果你的当前操作系统不是 Linux，将对应架构的 Linux 可执行文件下载到一个目录，用该目录路径替换 `~/.cargo/bin`。
 
 ```bash


### PR DESCRIPTION
I wasn't able to run the image with the provided command with Docker through Colima on macOS, but specifying the platform with `--platform linux/amd64` did the trick, so I updated the description, in case it might be of help to someone else.